### PR TITLE
Reduce voltage for msm8916

### DIFF
--- a/arch/arm/boot/dts/samsung/msm8916/msm8916-regulator.dtsi
+++ b/arch/arm/boot/dts/samsung/msm8916/msm8916-regulator.dtsi
@@ -17,8 +17,8 @@
 			compatible = "qcom,spm-regulator";
 			regulator-name = "8916_s2";
 			reg = <0x1700 0x100>;
-			regulator-min-microvolt = <1000000>;
-			regulator-max-microvolt = <1385000>;
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <850000>;
 		};
 	};
 };
@@ -52,8 +52,8 @@
 		regulator-min-microvolt = <1>;
 		regulator-max-microvolt = <10>;
 
-		qcom,cpr-voltage-ceiling = <1000000 1150000 1385000>;
-		qcom,cpr-voltage-floor = <1000000 1150000 1350000>;
+		qcom,cpr-voltage-ceiling = <500000 650000 850000>;
+		qcom,cpr-voltage-floor = <500000 650000 850000>;
 		vdd-apc-supply = <&pm8916_s2>;
 
 		qcom,vdd-mx-corner-map = <4 5 7>;
@@ -85,7 +85,7 @@
 					<27 36 6 0>,
 					<27 18 6 0>,
 					<27 0 6 0>;
-		qcom,cpr-init-voltage-ref = <1000000 1150000 1385000>;
+		qcom,cpr-init-voltage-ref = <500000 650000 850000>;
 		qcom,cpr-init-voltage-step = <10000>;
 		qcom,cpr-corner-map = <1 1 2 2 3 3 3 3 3 3>;
 		qcom,cpr-corner-frequency-map =


### PR DESCRIPTION
Ultimate powersaving and performace by undervolt. Excessive power usage is the main cause of overheating and killing performance. Update ramdisk, dt.img or sysfs mounted in /sys to apply new voltage.